### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# Original Repo
+# Searoutes
 
-https://github.com/eurostat/searoute
-
+Based on [Github/eurostat/searoute](https://github.com/eurostat/searoute).
 
 To simplify deploy, we pulled in the [SeaRoute-war](https://jarcasting.de/artifacts/eu.europa.ec.eurostat/searoute-war/)
 and removed all other files from the original repository.
 
 > Eurostat is the statistical office of the European Union. This repository provides with open resources (prototypes, proofs of concept,...) developed in-house.
 
+## Description
 
-# Searoutes
 ## API
 
-```
+```shell
 GET   http://localhost:5017/seaws?opos=174.8,-36.8&dpos=121.8,31.2&res=5
 ```
 
@@ -51,10 +50,10 @@ Returns
 }
 ```
 
-
 ## Local Testing
 
 Build a docker image
+
 ```shell
 docker build -t localhost/searoutes:3.6 .
 ```
@@ -67,10 +66,9 @@ docker run -it --rm -p 5017:5017 localhost/searoutes:3.6
 
 (NOTE: on ECS, we default to exposing ports in the 5xxx range for internal side-car containers)
 
-
 ## Building & Publishing
 
-https://hub.docker.com/repository/docker/dblworks/searoutes
+[Docker/dblworks/searoutes](https://hub.docker.com/r/dblworks/searoutes)
 
 ```shell
 docker pull dblworks/searoutes:3.6
@@ -83,6 +81,7 @@ export TAGNAME=3.6
 Build:
 
 On a x86 chip
+
 ```shell
 docker build -t dblworks/searoutes:$TAGNAME .
 ```
@@ -92,7 +91,6 @@ On a ARM chip (for a x86 target):
 ```shell
 docker build -t dblworks/searoutes:$TAGNAME . --platform amd64
 ```
-
 
 Publish:
 


### PR DESCRIPTION
* ensure docker has latest updates for packages to reduce vulnerabilities
* clean up readme

✅ tested the docker image locally, works



This fixes several vulnerabilities, but not all. 
<img width="738" alt="image" src="https://github.com/dbl-works/searoutes/assets/20702503/d11facaf-b748-46e3-8fba-e9c831225335">

comparing this to the base image https://hub.docker.com/layers/library/tomcat/9.0-jre17-temurin-focal/images/sha256-d55d3a14efa5ebf334d5cfdfc560fc84302fdfffc1acdc4c4a9cb5df48eafd73?context=explore
<img width="963" alt="image" src="https://github.com/dbl-works/searoutes/assets/20702503/dff34469-aa0b-48d4-b9eb-da9457e2b78b">

It might be, that the original searoutes WAR file contains these vulnerabilities. Unfortunately, there haven't been any updates to it since 2022.